### PR TITLE
Fixed reporting errors for missing links to files other than `*.html`.

### DIFF
--- a/walker.js
+++ b/walker.js
@@ -6,29 +6,28 @@ const walk = require('walk')
 function walker(directory, handler, callback) {
     const walker = walk.walk(directory)
     walker.on('file', function (parent, fileStats, next) {
-        if (path.extname(fileStats.name) != '.html') {
-            return next()
-        }
         const filePath = path.resolve(parent, fileStats.name)
-        fs.readFile(filePath, 'utf8', function (err, content) {
+        const relative = path.relative(filePath, directory)
+        const base = path.resolve(filePath, relative)
+        const relativeFilePath = filePath.substr(base.length + 1)
+        if (path.extname(fileStats.name) != '.html') {
+            handler(relativeFilePath, '')
+            next()
+        }
+        fs.readFile(filePath, 'utf8', (err, content) => {
             if (err) {
                 console.error(err)
                 return next()
             }
-            const relative = path.relative(filePath, directory)
-            const base = path.resolve(filePath, relative)
-            const relativeFilePath = filePath.substr(base.length + 1)
             handler(relativeFilePath, content)
             next()
         })
     })
-    walker.on('errors', function (parent, nodeStatsArray, next) {
+    walker.on('errors', (_parent, _nodeStatsArray, next) => {
         console.log('error', arguments)
         next()
     })
-    walker.on('end', function () {
-        callback()
-    })
+    walker.on('end', callback)
 }
 
 module.exports = walker


### PR DESCRIPTION
Some documentations can have binary files with links to them, and `link-checker` will report these files as missing.

I propose to add these files to set of local files but with empty content so they won't be processed as HTML files but won't be reported as missing.