### PR TITLE
Add failing test to demonstrate issue #12

### DIFF
--- a/test/fixture-root-relative-url/dir-a/source.html
+++ b/test/fixture-root-relative-url/dir-a/source.html
@@ -1,0 +1,3 @@
+<body>
+	<a href="/dir-b/target.html">dir-b/target</a>
+</body>

--- a/test/fixture-root-relative-url/dir-b/target.html
+++ b/test/fixture-root-relative-url/dir-b/target.html
@@ -1,0 +1,3 @@
+<body>
+  This page is the target of a link in <samp>../dir-a/source.html</samp>.
+</body>

--- a/test/test.js
+++ b/test/test.js
@@ -48,6 +48,27 @@ describe('link checker', () => {
 		})
 	})
 
+	it('run link checker with root-relative-url fixtures', () => {
+		return checker(dir('root-relative-url'), {['warn-name-attr']: true}).then(result => {
+			const expectedErrors = []
+			const expectedWarnings = []
+
+			expect(result.stats.errors).eql(expectedErrors)
+			expect(result.stats.warnings).eql(expectedWarnings)
+			expect(result.stats).eql({
+				parsedFiles: 2,
+				localLinks: 1,
+				localAnchorLinks: 0,
+				remoteLinks: 0,
+				remoteAnchorLinks: 0,
+				parentLinks: 0,
+				parentAnchorLinks: 0,
+				errors: expectedErrors,
+				warnings: expectedWarnings
+			})
+		})
+	})
+
 	it('run link checker with scaladoc fixtures', () => {
 		return checker(dir('scaladoc'), {javadoc: true}).then(result => {
 			const expectedErrors = [ { type: 'page',


### PR DESCRIPTION
Origin-relative URLs are parsed as relative to the directory
they're in. Reported in #12.